### PR TITLE
feat(adhoc-filter-simple-tab): Adding filter options functionality for presto database

### DIFF
--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -42,6 +42,7 @@ import { Input } from 'src/components/Input';
 import { optionLabel } from 'src/utils/common';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
 import useAdvancedDataTypes from './useAdvancedDataTypes';
+import { useToasts } from 'src/components/MessageToasts/withToasts';
 
 const StyledInput = styled(Input)`
   margin-bottom: ${({ theme }) => theme.gridUnit * 4}px;
@@ -260,6 +261,7 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
   const [loadingComparatorSuggestions, setLoadingComparatorSuggestions] =
     useState<boolean>(false);
   const [showFilterInput, setShowFilterInput] = useState<boolean>(false);
+  const { addDangerToast } = useToasts();
 
   const {
     advancedDataTypesState,
@@ -391,18 +393,26 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
           endpoint: `/superset/filter/${datasource.type}/${datasource.id}/${col}/`,
         })
           .then(({ json }) => {
-            setSuggestions(
-              json.map((suggestion: null | number | boolean | string) => ({
-                value: suggestion,
-                label: optionLabel(suggestion),
-              })),
-            );
+            if(!json){
+              setShowFilterInput(true)
+              setSuggestions([])
+            }
+            else{
+              setSuggestions(
+                json.map((suggestion: null | number | boolean | string) => ({
+                  value: suggestion,
+                  label: optionLabel(suggestion),
+                })),
+              );
+            }
             setLoadingComparatorSuggestions(false);
           })
-          .catch(() => {
+          .catch((error) => {
+            addDangerToast(error && error.statusText ? error.statusText : t('NOT_SUPPORTED'));
             setSuggestions([]);
             setShowFilterInput(true);
             setLoadingComparatorSuggestions(false);
+
           });
       } else {
         setShowFilterInput(true);

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopoverSimpleTabContent/index.tsx
@@ -41,8 +41,8 @@ import { Tooltip } from 'src/components/Tooltip';
 import { Input } from 'src/components/Input';
 import { optionLabel } from 'src/utils/common';
 import { FeatureFlag, isFeatureEnabled } from 'src/featureFlags';
-import useAdvancedDataTypes from './useAdvancedDataTypes';
 import { useToasts } from 'src/components/MessageToasts/withToasts';
+import useAdvancedDataTypes from './useAdvancedDataTypes';
 
 const StyledInput = styled(Input)`
   margin-bottom: ${({ theme }) => theme.gridUnit * 4}px;
@@ -393,11 +393,10 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
           endpoint: `/superset/filter/${datasource.type}/${datasource.id}/${col}/`,
         })
           .then(({ json }) => {
-            if(!json){
-              setShowFilterInput(true)
-              setSuggestions([])
-            }
-            else{
+            if (!json) {
+              setShowFilterInput(true);
+              setSuggestions([]);
+            } else {
               setSuggestions(
                 json.map((suggestion: null | number | boolean | string) => ({
                   value: suggestion,
@@ -407,12 +406,13 @@ const AdhocFilterEditPopoverSimpleTabContent: React.FC<Props> = props => {
             }
             setLoadingComparatorSuggestions(false);
           })
-          .catch((error) => {
-            addDangerToast(error && error.statusText ? error.statusText : t('NOT_SUPPORTED'));
+          .catch(error => {
+            addDangerToast(
+              error && error.statusText ? error.statusText : t('NOT_SUPPORTED'),
+            );
             setSuggestions([]);
             setShowFilterInput(true);
             setLoadingComparatorSuggestions(false);
-
           });
       } else {
         setShowFilterInput(true);

--- a/superset/config.py
+++ b/superset/config.py
@@ -422,7 +422,7 @@ DEFAULT_FEATURE_FLAGS: Dict[str, bool] = {
     # Allow users to export full CSV of table viz type.
     # This could cause the server to run out of memory or compute.
     "ALLOW_FULL_CSV_EXPORT": False,
-    "UX_BETA": False,
+    "UX_BETA": True,
     "GENERIC_CHART_AXES": False,
     "ALLOW_ADHOC_SUBQUERY": False,
     "USE_ANALAGOUS_COLORS": True,


### PR DESCRIPTION
feat(adhoc-filter-simple-tab): Adding filter options functionality for presto database.

**SUMMARY**

1- Enabling filter-select option from config.py for presto database.
2- Adding suggestions dropdown.
3- loading addition inside the 'Select Suggestion' dropdown.
4- Toaster Addition incase of 'No options available'
5- Rendering 'default filter field' incase of options not found from the database.

**BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF**

<img width="1498" alt="BeforeUI" src="https://user-images.githubusercontent.com/48474146/177038735-3a9bbe33-2ec3-4854-a863-2a26c9e44931.png">


![AfterUI](https://user-images.githubusercontent.com/48474146/177038757-836d5397-72e9-4e87-8b8e-f279a504adcb.gif)

**TESTING INSTRUCTIONS**

1- Setting UX_BETA check to 'True' in config.py. 
2- Select datasets, Can check on any of the datasets.
3- Open filter box and select simple tab.
4- Select options and check for the suggestions.

