### PR TITLE
feat (DNA-1455,DNA-1457, DNA-1458): Flash column manipulation and TTL updating cases

### DIFF
--- a/superset-frontend/src/views/CRUD/flash/components/FlashGrid/FlashList.tsx
+++ b/superset-frontend/src/views/CRUD/flash/components/FlashGrid/FlashList.tsx
@@ -188,16 +188,6 @@ function FlashList({ addDangerToast, addSuccessToast }: FlashListProps) {
         size: 'l',
       },
       {
-        Header: t('Slack Channel'),
-        accessor: 'teamSlackChannel',
-        size: 'xl',
-      },
-      {
-        Header: t('Slack Handle'),
-        accessor: 'teamSlackHandle',
-        size: 'xl',
-      },
-      {
         accessor: 'ttl',
         Header: t('TTL'),
         disableSortBy: true,
@@ -205,6 +195,11 @@ function FlashList({ addDangerToast, addSuccessToast }: FlashListProps) {
       {
         accessor: 'lastRefreshTime',
         Header: t('Last Refresh Time'),
+        disableSortBy: true,
+      },
+      {
+        accessor: 'nextRefreshTime',
+        Header: t('Next Refresh Time'),
         disableSortBy: true,
       },
       {
@@ -229,13 +224,14 @@ function FlashList({ addDangerToast, addSuccessToast }: FlashListProps) {
           const handleView = () => changeViewFlash(original);
 
           const actions: ActionProps[] | [] = [
-            (original?.owner === user?.email || user?.roles?.Admin) && {
-              label: 'export-action',
-              tooltip: t('Extend TTL'),
-              placement: 'bottom' as TooltipPlacement,
-              icon: 'Share',
-              onClick: handleChangeTtl,
-            },
+            original?.flashType !== FlashTypesEnum.ONE_TIME &&
+              (original?.owner === user?.email || user?.roles?.Admin) && {
+                label: 'export-action',
+                tooltip: t('Extend TTL'),
+                placement: 'bottom' as TooltipPlacement,
+                icon: 'Share',
+                onClick: handleChangeTtl,
+              },
             {
               label: 'ownership-action',
               tooltip: t('Change Ownership'),

--- a/superset-frontend/src/views/CRUD/flash/components/FlashView/FlashView.tsx
+++ b/superset-frontend/src/views/CRUD/flash/components/FlashView/FlashView.tsx
@@ -203,6 +203,16 @@ const FlashView: FunctionComponent<FlashViewButtonProps> = ({
               : 'NIL'}
           </Value>
         </StyledCol>
+        <StyledCol xs={5}>
+          <Label>Next Refresh Time:</Label>
+        </StyledCol>
+        <StyledCol xs={7}>
+          <Value>
+            {flash?.nextRefreshTime
+              ? moment(flash?.nextRefreshTime).format('DD/MM/YYYY hh:mm:ss A')
+              : 'NIL'}
+          </Value>
+        </StyledCol>
       </Row>
       <Row css={{ justifyContent: 'flex-end' }}>
         <Button onClick={() => openAuditLogs()}>Audit Logs</Button>

--- a/superset-frontend/src/views/CRUD/flash/types.ts
+++ b/superset-frontend/src/views/CRUD/flash/types.ts
@@ -68,6 +68,7 @@ export type FlashServiceObject = {
   flashType: string;
   id?: number;
   lastRefreshTime?: string;
+  nextRefreshTime?: string;
   retryCount?: number;
   createdAt?: string;
   updatedAt?: string;

--- a/superset/config.py
+++ b/superset/config.py
@@ -513,7 +513,9 @@ FLASH_TTL = {
         "ui:order": [
             "ttl",
         ],
-        "ttl": {"ui:help": "Flash object validity"},
+        "ttl": {
+            "ui:help": "Flash object validity (can extend TTL up to 7 days for SHORT TERM and 90 days for LONG TERM"
+        },
     },
     "VALIDATION": [],
 }


### PR DESCRIPTION
- [x] Adding Column 'Next Refresh Time' in Grid
- [x] Removing columns 'Slack Channel' & 'Slack Handle' from Grid
- [x] Hiding 'Extend TTL' action when flash type is 'One Time'.
- [x] Restricting TTL extension to 7 or 90 days a/c to flash type
