### PR TITLE
fix: Trino timestamp(3) support added in Charts sql queries

### DIFF
--- a/superset/db_engine_specs/trino.py
+++ b/superset/db_engine_specs/trino.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import logging
 from contextlib import closing
+import re
+from datetime import datetime
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
 
 import simplejson as json
 from flask import current_app
@@ -49,6 +52,29 @@ class TrinoEngineSpec(PrestoBaseEngineSpec):
     engine = "trino"
     engine_name = "Trino"
     has_catalogs = True
+
+    @classmethod
+    def convert_dttm(
+        cls, target_type: str, dttm: datetime, db_extra: Optional[Dict[str, Any]] = None
+    ) -> Optional[str]:
+        """
+        Convert a Python `datetime` object to a SQL expression.
+        :param target_type: The target type of expression
+        :param dttm: The datetime object
+        :param db_extra: The database extra object
+        :return: The SQL expression
+        Superset only defines time zone naive `datetime` objects, though this method
+        handles both time zone naive and aware conversions.
+        """
+        tt = target_type.upper()
+        if tt == utils.TemporalType.DATE:
+            return f"DATE '{dttm.date().isoformat()}'"
+        if re.sub(r"\(\d\)", "", tt) in (
+            utils.TemporalType.TIMESTAMP,
+            utils.TemporalType.TIMESTAMP_WITH_TIME_ZONE,
+        ):
+            return f"""TIMESTAMP '{dttm.isoformat(timespec="microseconds", sep=" ")}'"""
+        return None
 
     @classmethod
     def get_catalog_names(cls, inspector: Inspector) -> List[str]:

--- a/tests/integration_tests/db_engine_specs/trino_tests.py
+++ b/tests/integration_tests/db_engine_specs/trino_tests.py
@@ -18,11 +18,14 @@ import json
 from typing import Any, Dict
 from unittest.mock import Mock, patch
 
+
 import pytest
+from sqlalchemy import types
 
 import superset.config
 from superset.constants import USER_AGENT
 from superset.db_engine_specs.trino import TrinoEngineSpec
+from superset.utils.core import GenericDataType
 from tests.integration_tests.db_engine_specs.base_tests import TestDbEngineSpec
 
 
@@ -165,4 +168,32 @@ class TestTrinoDbEngineSpec(TestDbEngineSpec):
         assert str(excinfo.value) == (
             f"For security reason, custom authentication '{auth_method}' "
             f"must be listed in 'ALLOWED_EXTRA_AUTHENTICATIONS' config"
+        )
+
+    def test_convert_dttm(self):
+        dttm = self.get_dttm()
+
+        self.assertEqual(
+            TrinoEngineSpec.convert_dttm("TIMESTAMP", dttm),
+            "TIMESTAMP '2019-01-02 03:04:05.678900'",
+        )
+
+        self.assertEqual(
+            TrinoEngineSpec.convert_dttm("TIMESTAMP(3)", dttm),
+            "TIMESTAMP '2019-01-02 03:04:05.678900'",
+        )
+
+        self.assertEqual(
+            TrinoEngineSpec.convert_dttm("TIMESTAMP WITH TIME ZONE", dttm),
+            "TIMESTAMP '2019-01-02 03:04:05.678900'",
+        )
+
+        self.assertEqual(
+            TrinoEngineSpec.convert_dttm("TIMESTAMP(3) WITH TIME ZONE", dttm),
+            "TIMESTAMP '2019-01-02 03:04:05.678900'",
+        )
+
+        self.assertEqual(
+            TrinoEngineSpec.convert_dttm("DATE", dttm),
+            "DATE '2019-01-02'",
         )


### PR DESCRIPTION
Ref PR: [Trino Timestamp Issue](https://github.com/apache/superset/pull/21737)