### PR TITLE
feat(DNA-3166): Displaying actions as default instead of on hover

### DIFF
--- a/superset-frontend/src/components/TableCollection/index.tsx
+++ b/superset-frontend/src/components/TableCollection/index.tsx
@@ -148,7 +148,7 @@ export const Table = styled.table`
 
     .table-row {
       .actions {
-        opacity: 0;
+        opacity: 1;
         font-size: ${theme.typography.sizes.xl}px;
         display: flex;
       }


### PR DESCRIPTION
- [x] Action buttons to be shown on all the screens - Charts, Dashboards, Saved Queries, Flashes and Audit Logs

**BEFORE SCREENSHOT:**

<img width="1795" alt="Screenshot 2023-04-13 at 2 43 50 PM" src="https://user-images.githubusercontent.com/106157603/231721177-9f750daf-3a61-437a-9862-0340b9c482b9.png">

**AFTER SCREENSHOT:**

<img width="1798" alt="Screenshot 2023-04-13 at 2 43 06 PM" src="https://user-images.githubusercontent.com/106157603/231721206-3510d767-0384-4125-a6d2-ab57bd881436.png">

