### PR TITLE
feat(DNA-3821): Modify Working Timeout and Cron Schedule Options for Reports

### DIFF
--- a/superset-frontend/package-lock.json
+++ b/superset-frontend/package-lock.json
@@ -106,7 +106,7 @@
         "react-draggable": "^4.4.3",
         "react-gravatar": "^2.6.1",
         "react-hot-loader": "^4.12.20",
-        "react-js-cron": "^1.2.0",
+        "react-js-cron": "^2.0.0",
         "react-json-tree": "^0.11.2",
         "react-json-view": "^1.21.3",
         "react-jsonschema-form": "^1.8.1",
@@ -45077,9 +45077,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-js-cron": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-js-cron/-/react-js-cron-1.2.0.tgz",
-      "integrity": "sha512-mWxTmXkqP58ughdziS3qjEUVl1O03XEo8WDvr45/kTQfbd0C6ITniAsG5wZzwmTOgmrOKQheHog7L0TP683WUA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-js-cron/-/react-js-cron-2.0.0.tgz",
+      "integrity": "sha512-AryfzT1vnvQxhYgSZAsZLCs3HeUQsRYPjpm0bjT5itpySN/7UaM8ZjfyU7Bo40cfYbWpj/k77voIEo/Y8+r8yw==",
       "peerDependencies": {
         "antd": ">=4.6.0",
         "react": ">=16.8.0",
@@ -92222,9 +92222,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-js-cron": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-js-cron/-/react-js-cron-1.2.0.tgz",
-      "integrity": "sha512-mWxTmXkqP58ughdziS3qjEUVl1O03XEo8WDvr45/kTQfbd0C6ITniAsG5wZzwmTOgmrOKQheHog7L0TP683WUA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-js-cron/-/react-js-cron-2.0.0.tgz",
+      "integrity": "sha512-AryfzT1vnvQxhYgSZAsZLCs3HeUQsRYPjpm0bjT5itpySN/7UaM8ZjfyU7Bo40cfYbWpj/k77voIEo/Y8+r8yw==",
       "requires": {}
     },
     "react-json-tree": {

--- a/superset-frontend/package.json
+++ b/superset-frontend/package.json
@@ -170,7 +170,7 @@
     "react-draggable": "^4.4.3",
     "react-gravatar": "^2.6.1",
     "react-hot-loader": "^4.12.20",
-    "react-js-cron": "^1.2.0",
+    "react-js-cron": "^2.0.0",
     "react-json-tree": "^0.11.2",
     "react-json-view": "^1.21.3",
     "react-jsonschema-form": "^1.8.1",

--- a/superset-frontend/src/components/CronPicker/CronPicker.tsx
+++ b/superset-frontend/src/components/CronPicker/CronPicker.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import { ConfigProvider } from 'antd';
 import { styled, t } from '@superset-ui/core';
 import ReactCronPicker, { Locale, CronProps } from 'react-js-cron';
+import 'react-js-cron/dist/styles.css';
 
 export * from 'react-js-cron';
 

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
@@ -395,7 +395,27 @@ describe('AlertReportModal', () => {
     const saveButton = editReportWrapper.find(
       'button[data-test="modal-confirm-button"]',
     );
-    console.log('button', saveButton);
+    expect(saveButton.props().disabled).toBe(true);
+  });
+
+  it('If cron schedule * 1 1 * * for Reports the save button should be disabled', async () => {
+    const props = {
+      ...mockedProps,
+      alert: mockData,
+      isReport: true,
+    };
+    props.alert.crontab = '* 1 1 * *';
+    const editReportWrapper = await mountAndWait(props);
+    expect(
+      editReportWrapper.find('[data-test="alert-report-modal-title"]').text(),
+    ).toEqual('Edit Report');
+
+    expect(
+      editReportWrapper.find('input[name="crontab"]').props().value,
+    ).toEqual('* 1 1 * *');
+    const saveButton = editReportWrapper.find(
+      'button[data-test="modal-confirm-button"]',
+    );
     expect(saveButton.props().disabled).toBe(true);
   });
 

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
@@ -45,7 +45,7 @@ const mockData = {
   recipients: [
     { type: 'Slack', id: 6, recipient_config_json: '{"target": "xyz"}' },
   ],
-  working_timeout: 300,
+  working_timeout: 60,
   timezone: 'Antarctica/Mawson',
   msg_content: 'sss',
   type: 'Report',
@@ -415,6 +415,26 @@ describe('AlertReportModal', () => {
       editReportWrapper.find('input[name="crontab"]').props().value,
     ).toEqual('0 * * * *');
     const saveButton = editReportWrapper.find(
+      'button[data-test="modal-confirm-button"]',
+    );
+    expect(saveButton.props().disabled).toBe(false);
+  });
+
+  it('If cron schedule * * * * * (Every minute) for Alerts the Save button should be enabled', async () => {
+    const props = {
+      ...mockedProps,
+      alert: mockData,
+      isReport: false,
+    };
+    props.alert.crontab = '* * * * *';
+    props.alert.type = 'Alert';
+    props.alert.validator_type = 'operator';
+    props.alert.validator_config_json = '{"op": "==", "threshold": 1.0}';
+    const editAlertWrapper = await mountAndWait(props);
+    expect(
+      editAlertWrapper.find('input[name="crontab"]').props().value,
+    ).toEqual('* * * * *');
+    const saveButton = editAlertWrapper.find(
       'button[data-test="modal-confirm-button"]',
     );
     expect(saveButton.props().disabled).toBe(false);

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.test.jsx
@@ -39,6 +39,16 @@ const mockData = {
   chart: { id: 1, slice_name: 'test chart', viz_type: 'table' },
   database: { id: 1, database_name: 'test database' },
   sql: 'SELECT NaN',
+  crontab: '* * * * *',
+  log_retention: 30,
+  owners: [{ first_name: 'Samra', id: 3, last_Name: 'Hanif' }],
+  recipients: [
+    { type: 'Slack', id: 6, recipient_config_json: '{"target": "xyz"}' },
+  ],
+  working_timeout: 300,
+  timezone: 'Antarctica/Mawson',
+  msg_content: 'sss',
+  type: 'Report',
 };
 const FETCH_REPORT_ENDPOINT = 'glob:*/api/v1/report/*';
 const REPORT_PAYLOAD = { result: mockData };
@@ -363,5 +373,50 @@ describe('AlertReportModal', () => {
 
     const bypass = alertWrapper.find('[data-test="bypass-cache"]');
     expect(bypass).not.toExist();
+  });
+
+  // TEST CASES FOR REPORTS CRON SCHEDULE DISABLE
+
+  it('If cron schedule * * * * * (Every minute) for Reports the save button should be disabled', async () => {
+    const props = {
+      ...mockedProps,
+      alert: mockData,
+      isReport: true,
+    };
+
+    const editReportWrapper = await mountAndWait(props);
+    expect(
+      editReportWrapper.find('[data-test="alert-report-modal-title"]').text(),
+    ).toEqual('Edit Report');
+
+    expect(
+      editReportWrapper.find('input[name="crontab"]').props().value,
+    ).toEqual('* * * * *');
+    const saveButton = editReportWrapper.find(
+      'button[data-test="modal-confirm-button"]',
+    );
+    console.log('button', saveButton);
+    expect(saveButton.props().disabled).toBe(true);
+  });
+
+  it('If cron schedule 0 * * * * (Every hour) for Reports the Save button should be enabled', async () => {
+    const props = {
+      ...mockedProps,
+      alert: mockData,
+      isReport: true,
+    };
+    props.alert.crontab = '0 * * * *';
+    const editReportWrapper = await mountAndWait(props);
+    expect(
+      editReportWrapper.find('[data-test="alert-report-modal-title"]').text(),
+    ).toEqual('Edit Report');
+
+    expect(
+      editReportWrapper.find('input[name="crontab"]').props().value,
+    ).toEqual('0 * * * *');
+    const saveButton = editReportWrapper.find(
+      'button[data-test="modal-confirm-button"]',
+    );
+    expect(saveButton.props().disabled).toBe(false);
   });
 });

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -425,12 +425,12 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
   addSuccessToast,
 }) => {
   const conf = useCommonConf();
-  const currentNotification = JSON.parse(
-    JSON.stringify(conf?.ALERT_REPORTS_NOTIFICATION_METHODS),
-  );
-  const reportNotificationsAllowed = currentNotification.filter(
-    (item: any) => item !== RecipientIconName.VO,
-  );
+  const currentNotification = conf?.ALERT_REPORTS_NOTIFICATION_METHODS
+    ? JSON.parse(JSON.stringify(conf?.ALERT_REPORTS_NOTIFICATION_METHODS))
+    : [];
+  const reportNotificationsAllowed = currentNotification
+    ? currentNotification.filter((item: any) => item !== RecipientIconName.VO)
+    : [];
   const allowedNotificationMethods: NotificationMethodOption[] =
     (isReport
       ? reportNotificationsAllowed

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -1028,7 +1028,8 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       checkNotificationSettings()
     ) {
       if (isReport) {
-        if (currentAlert.crontab === '* * * * *') {
+        const cron = currentAlert.crontab.split(' ');
+        if (cron.length === 5 && cron[0] === '*') {
           setDisableSave(true);
         } else {
           setDisableSave(false);

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -127,7 +127,8 @@ const RETENTION_OPTIONS = [
 
 const DEFAULT_RETENTION = 30;
 const DEFAULT_WORKING_TIMEOUT = 60;
-const MAX_WORKING_TIMEOUT = 300;
+const MAX_WORKING_TIMEOUT_ALERTS = 300;
+const MAX_WORKING_TIMEOUT_REPORTS = 900;
 const DEFAULT_CRON_VALUE = '0 * * * *'; // every hour
 const DEFAULT_ALERT = {
   active: true,
@@ -421,8 +422,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
     DEFAULT_NOTIFICATION_METHODS;
 
   const [disableSave, setDisableSave] = useState<boolean>(true);
-  const [maxWorkingTimeout, setMaxWorkingTimeout] =
-    useState<number>(MAX_WORKING_TIMEOUT);
+  const [maxWorkingTimeout, setMaxWorkingTimeout] = useState<number>(
+    isReport ? MAX_WORKING_TIMEOUT_REPORTS : MAX_WORKING_TIMEOUT_ALERTS,
+  );
   const [invalidInput, setInvalidInputs] = useState<any>({
     invalid: false,
     emailError: '',
@@ -1159,7 +1161,10 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
 
   const displayTimeoutValidation = (cronSchedule: string) => {
     const minutePart = cronSchedule.split(' ')[0];
-    const timeout = getLeastTimeout(minutePart, MAX_WORKING_TIMEOUT);
+    const timeout = getLeastTimeout(
+      minutePart,
+      isReport ? MAX_WORKING_TIMEOUT_REPORTS : MAX_WORKING_TIMEOUT_ALERTS,
+    );
     setMaxWorkingTimeout(timeout);
   };
 

--- a/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
+++ b/superset-frontend/src/views/CRUD/alert/AlertReportModal.tsx
@@ -57,6 +57,7 @@ import {
   RecipientIconName,
 } from 'src/views/CRUD/alert/types';
 import { InfoTooltipWithTrigger } from '@superset-ui/chart-controls';
+import { PeriodType } from 'react-js-cron/dist/cjs/types';
 import { AlertReportCronScheduler } from './components/AlertReportCronScheduler';
 import { NotificationMethod } from './components/NotificationMethod';
 import { ERROR_MESSAGES } from './constants';
@@ -129,6 +130,21 @@ const DEFAULT_RETENTION = 30;
 const DEFAULT_WORKING_TIMEOUT = 60;
 const MAX_WORKING_TIMEOUT_ALERTS = 300;
 const MAX_WORKING_TIMEOUT_REPORTS = 900;
+const REPORTS_ALLOWED_PERIODS: PeriodType[] = [
+  'year',
+  'month',
+  'week',
+  'day',
+  'hour',
+];
+const DEFAULT_ALLOWED_PERIODS: PeriodType[] = [
+  'year',
+  'month',
+  'week',
+  'day',
+  'hour',
+  'minute',
+];
 const DEFAULT_CRON_VALUE = '0 * * * *'; // every hour
 const DEFAULT_ALERT = {
   active: true,
@@ -1012,7 +1028,11 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
       checkNotificationSettings()
     ) {
       if (isReport) {
-        setDisableSave(false);
+        if (currentAlert.crontab === '* * * * *') {
+          setDisableSave(true);
+        } else {
+          setDisableSave(false);
+        }
       } else if (
         !!currentAlert.database &&
         currentAlert.sql?.length &&
@@ -1367,6 +1387,9 @@ const AlertReportModal: FunctionComponent<AlertReportModalProps> = ({
                   currentAlert?.crontab || DEFAULT_CRON_VALUE,
                 );
               }}
+              allowedPeriods={
+                isReport ? REPORTS_ALLOWED_PERIODS : DEFAULT_ALLOWED_PERIODS
+              }
             />
             <div className="control-label">{t('Timezone')}</div>
             <div

--- a/superset-frontend/src/views/CRUD/alert/components/AlertReportCronScheduler.tsx
+++ b/superset-frontend/src/views/CRUD/alert/components/AlertReportCronScheduler.tsx
@@ -22,16 +22,17 @@ import { t, useTheme } from '@superset-ui/core';
 import { AntdInput, RadioChangeEvent } from 'src/components';
 import { Input } from 'src/components/Input';
 import { Radio } from 'src/components/Radio';
-import { CronPicker, CronError } from 'src/components/CronPicker';
+import { CronPicker, CronError, PeriodType } from 'src/components/CronPicker';
 import { StyledInputContainer } from 'src/views/CRUD/alert/AlertReportModal';
 
 export interface AlertReportCronSchedulerProps {
   value: string;
   onChange: (change: string) => any;
+  allowedPeriods?: PeriodType[];
 }
 
 export const AlertReportCronScheduler: React.FC<AlertReportCronSchedulerProps> =
-  ({ value, onChange }) => {
+  ({ value, onChange, allowedPeriods }) => {
     const theme = useTheme();
     const inputRef = useRef<AntdInput>(null);
     const [scheduleFormat, setScheduleFormat] = useState<'picker' | 'input'>(
@@ -76,6 +77,7 @@ export const AlertReportCronScheduler: React.FC<AlertReportCronSchedulerProps> =
               disabled={scheduleFormat !== 'picker'}
               displayError={scheduleFormat === 'picker'}
               onError={onError}
+              allowedPeriods={allowedPeriods}
             />
           </div>
           <div className="inline-container add-margin">


### PR DESCRIPTION
- [x] Set the **MAX_WORKING_TIMEOUT** validation for reports to 15 mins.
- [x] Bump `reactjs-cron` version to **2.0.0** from **1.2.0**
- [x] Adding CronSchedule allowPeriods key to dynamically populate 'Period Types'
- [x] Add validation for CronSchedule "* * * * *" i.e every minute not to be accepted for Reports.
- [x] Unit test cases for the above feature