### PR TITLE
feat(DNA-4501): schedule type replaced to schedule frequency and status ui

### DIFF
--- a/superset-frontend/src/views/CRUD/flash/components/FlashGrid/FlashList.tsx
+++ b/superset-frontend/src/views/CRUD/flash/components/FlashGrid/FlashList.tsx
@@ -256,6 +256,7 @@ function FlashList({ addDangerToast, addSuccessToast }: FlashListProps) {
         },
         Header: t('Database Name'),
         accessor: 'datastoreId',
+        size: 'xs',
       },
       {
         Header: t('Flash Type: Flash Name (Schedule Frequency)'),
@@ -361,12 +362,20 @@ function FlashList({ addDangerToast, addSuccessToast }: FlashListProps) {
         }: any) => (
           <span
             css={(theme: Theme) => css`
-              color: ${theme.colors.grayscale.light5};
-              padding: 4px 6px 4px 6px;
+              display: inline-block;
+              padding: 8px 12px;
+              font-size: 12px;
               font-weight: 700;
-              border: block;
-              opacity: 0.8;
-              background: ${getFlashStatusColor(status, theme)};
+              width: 100%;
+              text-align: center;
+              color: ${theme.colors.grayscale.light5};
+              background-color: ${getFlashStatusColor(status, theme).light};
+              border-radius: 4px;
+              transition: opacity 0.2s ease-in-out;
+              &:hover {
+                opacity: 1;
+                background-color: ${getFlashStatusColor(status, theme).dark};
+              }
             `}
           >
             {status}
@@ -374,6 +383,7 @@ function FlashList({ addDangerToast, addSuccessToast }: FlashListProps) {
         ),
         Header: t('Status'),
         accessor: 'status',
+        size: 'sm',
       },
       {
         Cell: ({ row: { original } }: any) => {
@@ -505,7 +515,7 @@ function FlashList({ addDangerToast, addSuccessToast }: FlashListProps) {
         input: 'date',
       },
       {
-        Header: t('Schedule Type'),
+        Header: t('Schedule Frequency'),
         id: 'scheduleType',
         input: 'select',
         operator: FilterOperator.equals,

--- a/superset-frontend/src/views/CRUD/flash/components/FlashView/FlashView.tsx
+++ b/superset-frontend/src/views/CRUD/flash/components/FlashView/FlashView.tsx
@@ -137,7 +137,7 @@ const FlashView: FunctionComponent<FlashViewButtonProps> = ({
           <Value>{flash?.ttl ? convertTollDate(flash?.ttl) : 'N/A'}</Value>
         </StyledCol>
         <StyledCol xs={5}>
-          <Label>Schedule Type:</Label>
+          <Label>Schedule Frequency:</Label>
         </StyledCol>
         <StyledCol xs={7}>
           <Value>{flash?.scheduleType ? flash?.scheduleType : 'N/A'}</Value>

--- a/superset-frontend/src/views/CRUD/flash/components/helper.ts
+++ b/superset-frontend/src/views/CRUD/flash/components/helper.ts
@@ -39,17 +39,29 @@ export const getFlashStatusColor = (status: string, theme: Theme) => {
     status === FLASH_STATUS_ENUMS.UPDATED ||
     status === FLASH_STATUS_ENUMS.IN_PROGRESS
   ) {
-    return theme.colors.warning.dark1;
+    return {
+      light: theme.colors.warning.light1,
+      dark: theme.colors.warning.dark1,
+    };
   }
   if (status === FLASH_STATUS_ENUMS.MATERIALIZED) {
-    return theme.colors.success.dark1;
+    return {
+      light: theme.colors.success.light1,
+      dark: theme.colors.success.dark2,
+    };
   }
   if (
     status === FLASH_STATUS_ENUMS.MATERIALIZED_FAILED ||
     status === FLASH_STATUS_ENUMS.DELETED ||
     status === FLASH_STATUS_ENUMS.MARKED_FOR_DELETION
   ) {
-    return theme.colors.error.dark1;
+    return {
+      light: theme.colors.error.light1,
+      dark: theme.colors.error.dark1,
+    };
   }
-  return theme.colors.grayscale.dark1;
+  return {
+    light: theme.colors.grayscale.light1,
+    dark: theme.colors.grayscale.dark1,
+  };
 };

--- a/superset/config.py
+++ b/superset/config.py
@@ -342,7 +342,7 @@ FLASH_CREATION = {
                                 "pattern": "^(@)[A-Za-z0-9_-\\s]+$",
                             },
                             "scheduleType": {
-                                "title": "Schedule Type",
+                                "title": "Schedule Frequency",
                                 "type": "string",
                                 "enum": ["", "Hourly", "Daily", "Weekly", "Monthly"],
                                 "enumNames": [
@@ -371,7 +371,7 @@ FLASH_CREATION = {
                         "properties": {
                             "flashType": {"enum": ["Short Term"]},
                             "scheduleType": {
-                                "title": "Schedule Type",
+                                "title": "Schedule Frequency",
                                 "type": "string",
                                 "enum": ["", "Hourly", "Daily", "Weekly", "Monthly"],
                                 "enumNames": [
@@ -422,7 +422,7 @@ FLASH_CREATION = {
             "ui:help": "Slack handle for notification",
         },
         "ttl": {"ui:help": "Flash object validity"},
-        "scheduleType": {"ui:help": "Schedule type for the Flash object"},
+        "scheduleType": {"ui:help": "Schedule Frequency for the Flash object"},
         "scheduleStartTime": {
             "ui:help": "Start time from which the flash object is to be scheduled."
         },
@@ -585,7 +585,7 @@ FLASH_TYPE = {
                                 "pattern": "^(@)[A-Za-z0-9_-\\s]+$",
                             },
                              "scheduleType": {
-                                "title": "Schedule Type",
+                                "title": "Schedule Frequency",
                                 "type": "string",
                                 "enum": ["", "Hourly", "Daily", "Weekly", "Monthly"],
                                 "enumNames": [
@@ -614,7 +614,7 @@ FLASH_TYPE = {
                         "properties": {
                             "flashType": {"enum": ["Short Term"]},
                             "scheduleType": {
-                                "title": "Schedule Type",
+                                "title": "Schedule Frequency",
                                 "type": "string",
                                 "enum": ["", "Hourly", "Daily", "Weekly", "Monthly"],
                                 "enumNames": [
@@ -651,7 +651,7 @@ FLASH_TYPE = {
             "ui:placeholder": "@slack_handle_name",
             "ui:help": "Slack handle for notification",
         },
-        "scheduleType": {"ui:help": "Schedule type for the Flash object"},
+        "scheduleType": {"ui:help": "Schedule Frequency for the Flash object"},
         "scheduleStartTime": {
             "ui:help": "Start time from which the flash object is to be scheduled."
         },
@@ -668,7 +668,7 @@ FLASH_SCHEDULE = {
         "type": "object",
         "properties": {
             "scheduleType": {
-                "title": "Schedule Type",
+                "title": "Schedule Frequency",
                 "type": "string",
                 "enum": ["", "Hourly", "Daily", "Weekly", "Monthly"],
                 "enumNames": [
@@ -696,7 +696,7 @@ FLASH_SCHEDULE = {
             "scheduleType",
             "scheduleStartTime",
         ],
-        "scheduleType": {"ui:help": "Schedule type for the Flash object"},
+        "scheduleType": {"ui:help": "Schedule Frequency for the Flash object"},
         "scheduleStartTime": {
             "ui:help": "Start time from which the flash object is to be scheduled"
         },


### PR DESCRIPTION
- [x] Rename schedule type to 'Schedule Frequency' in the overall application
- [x] Modify Flash Status UI
- [x] Remove extra spaces from grid

**BEFORE:**
<img width="1800" alt="Screenshot 2023-06-22 at 9 55 08 PM" src="https://github.com/careem/superset/assets/106157603/1b8999f5-ab54-41c7-930a-ba3b334257d1">

**AFTER:**
<img width="1799" alt="Screenshot 2023-06-22 at 9 54 27 PM" src="https://github.com/careem/superset/assets/106157603/421ba9f2-2ef4-4117-a7de-b6d49579851f">

<img width="1799" alt="Screenshot 2023-06-22 at 9 54 09 PM" src="https://github.com/careem/superset/assets/106157603/c55b6f5f-b5e0-4a85-b0ab-9941f2a2430e">
